### PR TITLE
Fix prompt for channel conversation summarization

### DIFF
--- a/listeners/listener_utils/listener_constants.py
+++ b/listeners/listener_utils/listener_constants.py
@@ -9,6 +9,6 @@ Hi there! You didn't provide a message with your mention.
 SUMMARIZE_CHANNEL_WORKFLOW = """
 A user has just joined this Slack channel.
 Please create a quick summary of the conversation in this channel to help them catch up.
-Don't use usernames in your response.
+Don't use user IDs or names in your response.
 """
 DEFAULT_LOADING_TEXT = "Thinking..."

--- a/listeners/listener_utils/listener_constants.py
+++ b/listeners/listener_utils/listener_constants.py
@@ -7,8 +7,8 @@ Hi there! You didn't provide a message with your mention.
     Mention me again in this thread so that I can help you out!
 """
 SUMMARIZE_CHANNEL_WORKFLOW = """
-User has just joined this slack channel.
-Create a quick summary of the conversaton in this channel to cath up the user.
-Don't use user names in your response.
+A user has just joined this Slack channel.
+Please create a quick summary of the conversation in this channel to help them catch up.
+Don't use usernames in your response.
 """
 DEFAULT_LOADING_TEXT = "Thinking..."


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

My initial intent was to fix typos `conversaton`, and `cath` in the prompt for channel conversation summarization,
but went ahead and updated it overall without changing the intent of the prompt.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
