### PR TITLE
chore(deps): pin pytest and ruff to exact versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 slack-bolt==1.28.0
-pytest
-ruff
+pytest==9.1.1
+ruff==0.15.19
 slack-cli-hooks==0.3.0
 openai==2.40.0
 anthropic==0.105.2


### PR DESCRIPTION
This pull request pins the two remaining unpinned dependencies in `requirements.txt`.

### Summary

- `pytest` and `ruff` were unpinned, so CI resolved the latest release at run time.
- Pinned both to exact `==` versions (`pytest==9.1.1`, `ruff==0.15.19`) for reproducible lint/format runs; Dependabot drives future bumps.
- All other deps (slack-bolt, slack-cli-hooks, openai, anthropic, google-cloud-aiplatform) were already pinned.

### Testing

- `ruff check .` and `ruff format --check .` pass with the pinned 0.15.19 (matches the CI workflow).
